### PR TITLE
Improvement Request: Adding exceptions handling in cli/main.py and api/build.py files 

### DIFF
--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -14,6 +14,8 @@ from binary_wheel_builder.api.meta import (Wheel, WheelFileEntry, WheelPlatformB
 from binary_wheel_builder.wheel.reproducible import ReproducibleWheelFile
 from binary_wheel_builder.wheel.util import generate_metadata_file, generate_wheel_file
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def _write_wheel(
         out_dir: str,
@@ -22,7 +24,7 @@ def _write_wheel(
         metadata: dict,
         wheel_file_entries: list[WheelFileEntry]
 ):
-    wheel_file_path = os.path.join(out_dir, wheel.wheel_filename(tag))
+    wheel_file_path = Path(out_dir) / wheel.wheel_filename(tag))
 
     entries = [
         *wheel_file_entries,
@@ -106,7 +108,8 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
     :return: Yields for each generated platform wheel
     """
     dist_folder.mkdir(exist_ok=True)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+    worker_count = worker_count or os.cpu_count()
+    with concurrent.futures.ProcessPoolExecutor(max_workers=worker_count) as executor:
         futures = [
             executor.submit(
                 _build_wheel_for_platform,

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -40,9 +40,21 @@ def main(argv=None) -> None:
     args = _parse_args(argv)
 
     dist_path = Path(args.dist_folder)
-    dist_path.mkdir(exist_ok=True)
+    
+   try:
+        dist_path.mkdir(exist_ok=True)
+    except OSError as e:
+        raise SystemExit(f"Failed to create dist folder at '{dist_path}': {e}")
 
     from binary_wheel_builder.cli.config_file import load_wheel_spec_from_yaml
-    wheel = load_wheel_spec_from_yaml(Path(args.wheel_spec))
-    for result in build_wheel(wheel, dist_path, worker_count=args.max_workers):
-        print(f"> {result.checksum} - {result.file_path}")
+     
+    try:
+        wheel = load_wheel_spec_from_yaml(Path(args.wheel_spec))
+    except Exception as e:
+        raise SystemExit(f"Failed to load wheel spec from '{args.wheel_spec}': {e}")
+
+    try:
+        for result in build_wheel(wheel, dist_path, worker_count=args.max_workers):
+            print(f"> {result.checksum} - {result.file_path}")
+    except Exception as e:
+          raise SystemExit(f"Error occurred while building wheels: {e}")

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -25,6 +25,11 @@ def _parse_args(args) -> Namespace:
         type=int,
         help="Number of parallel workers to use at most for building wheels"
     )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='Wheel Builder 1.0.0'
+    )
     return parser.parse_args(args)
 
 


### PR DESCRIPTION
Hello, I´am a backend developer that works mostly with Python as freelance and I want to share my little contribution to the main branch for this repo that I really like how it looks !. 

### **CONTEXT**

I have rewieved your source code in detail and navigated for almost all folders and I have come to the conclussion that  we could add exception handling for build_wheel, since a failure to build a wheel should not stop the entire CLI. What do you think about it?


**MY PROPOSAL:**

1. Catch general errors:

Use try-except in the build_wheel function to catch general errors.
Use concurrent.futures.as_completed to catch thread errors and check for exceptions with future.exception().

2. Catch specific errors in _build_wheel_for_platform:

Catch errors in wheel creation and writing, especially when accessing or writing files.

3. Report errors in a clear way:

Show the affected platform and the error.
Add error traces (traceback.format_exc()) to facilitate debugging.

**MY CHANGES:**

1. I/O errors in dist_path.mkdir:

OSError is caught when the output folder cannot be created.
This prevents permission errors or invalid paths.

2. YAML file loading errors:

If load_wheel_spec_from_yaml fails, an error message is displayed with the file name.

3. Catching errors in build_wheel:

Errors in ThreadPoolExecutor threads are caught with future.exception().
An error message is displayed with the error traceback.format_exc()).

4. Errors specific to the _build_wheel_for_platform function:

File errors (OSError, IOError) are handled.
Unchecked errors are printed so that the user sees the full trace.

5. Security and robustness:

With these additions, the CLI tool will not stop at a single error in wheels creation.
Users will receive full details of errors.


SCREENSHOTS WITH THESE CHANGES ADDED:

![code(2)](https://github.com/user-attachments/assets/a6324768-2191-436a-8892-b8c1a0183312)
![code(1)](https://github.com/user-attachments/assets/5c8df548-70b0-463d-87c8-7d0b846cb7d4)

⚠NOTE: PLEASE IMPORT TRACEBACK DEPENDENCY TO WORK WHIT TRACEBACK EXCEPTION

#Backend  #BugFixes  #CLITools

