### PR TITLE
Updated and fixed the api/build.py and cli/main.py files

### DIFF
--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -14,8 +14,6 @@ from binary_wheel_builder.api.meta import (Wheel, WheelFileEntry, WheelPlatformB
 from binary_wheel_builder.wheel.reproducible import ReproducibleWheelFile
 from binary_wheel_builder.wheel.util import generate_metadata_file, generate_wheel_file
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
 
 def _write_wheel(
         out_dir: str,

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -125,7 +125,7 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
                     try:
                         yield future.result()
                     except Exception as e:
-                       logger.error(f"Unexpected result has ocurred", exc_info=True)
+                       logger.error(f"Unexpected error has ocurred", exc_info=True)
                        
 
 def _build_wheel_for_platform(dist_folder, python_platform, wheel_meta):

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from operator import attrgetter
 from zipfile import Path
 from pathlib import Path
+from logging import logger
 from binary_wheel_builder import wrapper_templates
 from binary_wheel_builder.api.meta import (Wheel, WheelFileEntry, WheelPlatformBuildResult, WheelPlatformIdentifier,
                                            WheelSource)
@@ -22,7 +23,7 @@ def _write_wheel(
         metadata: dict,
         wheel_file_entries: list[WheelFileEntry]
 ):
-    wheel_file_path = Path(out_dir) / wheel.wheel_filename(tag))
+    wheel_file_path = pathlib.Path(out_dir) / wheel.wheel_filename(tag))
 
     entries = [
         *wheel_file_entries,
@@ -118,7 +119,7 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
             )
             for future in concurrent.futures.as_completed(futures):
                 if future.exception() is not None:
-                   logger.error(f"Sorry, a problem has occurred :(. Ensure all data is correct 
+                   logger.error(f"Sorry, a problem has occurred. Ensure all data is correct 
                                 or configured. Exception: {future.exception()}", exc_info=True)
                 else:
                     try:

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -120,18 +120,18 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
                 wheel_meta
             )
              for python_platform in wheel_meta.platforms
-+        ]
-+
-+        for future in concurrent.futures.as_completed(futures):
-+            if future.exception() is not None:
-+                raise WheelBuildException(
-+                    "Unexpected error has occurred. Ensure all data is correct or configured"
-+                ) from future.exception()
-+
-+            try:
-+                yield future.result()
-+            except Exception as e:
-+                raise WheelBuildException("Unexpected error has occurred") from e
+         ]
+
+         for future in concurrent.futures.as_completed(futures):
+            if future.exception() is not None:
+                  raise WheelBuildException(
+                     "Unexpected error has occurred. Ensure all data is correct or configured"
+                 ) from future.exception()
+
+             try:
+                 yield future.result()
+             except Exception as e:
+                 raise WheelBuildException("Unexpected error has occurred") from e
                        
 
 def _build_wheel_for_platform(dist_folder, python_platform, wheel_meta):
@@ -148,11 +148,6 @@ def _build_wheel_for_platform(dist_folder, python_platform, wheel_meta):
                 file_path=wheel_path,
             )
   except (OSError, IOError) as e:
-        logger.error(f"File operation failed for platform {python_platform}: {e}", exc_info=True)
-        raise RuntimeError(f"File operation failed for platform {python_platform}: {e}")
-
-  WheelBuildException(Exception):
-     pass
-
+        raise RuntimeError(f"File operation failed for platform {python_platform}: {e}") 
   except Exception as e:
       raise WheelBuildException("Unhandled exception in _build_wheel_for_platform for platform ...") from e

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -135,19 +135,19 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
                        
 
 def _build_wheel_for_platform(dist_folder, python_platform, wheel_meta):
-  try: 
-      wheel_path = _write_platform_wheel_with_wrappers(
-            dist_folder.__str__(),
-            wheel_meta,
-            python_platform,
-            wheel_meta.source,
-        )
-        with open(wheel_path, 'rb') as wheel:
-            return WheelPlatformBuildResult(
-                checksum=hashlib.sha256(wheel.read()).hexdigest(),
-                file_path=wheel_path,
-            )
-  except (OSError, IOError) as e:
-        raise RuntimeError(f"File operation failed for platform {python_platform}: {e}") 
-  except Exception as e:
-      raise WheelBuildException("Unhandled exception in _build_wheel_for_platform for platform ...") from e
+    try: 
+        wheel_path = _write_platform_wheel_with_wrappers(
+              dist_folder.__str__(),
+              wheel_meta,
+              python_platform,
+              wheel_meta.source,
+          )
+          with open(wheel_path, 'rb') as wheel:
+              return WheelPlatformBuildResult(
+                  checksum=hashlib.sha256(wheel.read()).hexdigest(),
+                  file_path=wheel_path,
+              )
+    except (OSError, IOError) as e:
+          raise RuntimeError(f"File operation failed for platform {python_platform}: {e}") 
+    except Exception as e:
+        raise WheelBuildException("Unhandled exception in _build_wheel_for_platform for platform ...") from e

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -14,6 +14,8 @@ from binary_wheel_builder.api.meta import (Wheel, WheelFileEntry, WheelPlatformB
 from binary_wheel_builder.wheel.reproducible import ReproducibleWheelFile
 from binary_wheel_builder.wheel.util import generate_metadata_file, generate_wheel_file
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def _write_wheel(
         out_dir: str,
@@ -22,7 +24,7 @@ def _write_wheel(
         metadata: dict,
         wheel_file_entries: list[WheelFileEntry]
 ):
-    wheel_file_path = os.path.join(out_dir, wheel.wheel_filename(tag))
+    wheel_file_path = Path(out_dir) / wheel.wheel_filename(tag))
 
     entries = [
         *wheel_file_entries,
@@ -106,7 +108,8 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
     :return: Yields for each generated platform wheel
     """
     dist_folder.mkdir(exist_ok=True)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+    worker_count = worker_count or os.cpu_count()
+    with concurrent.futures.ProcessPoolExecutor(max_workers=worker_count) as executor:
         futures = [
             executor.submit(
                 _build_wheel_for_platform,

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -144,6 +144,9 @@ def _build_wheel_for_platform(dist_folder, python_platform, wheel_meta):
   except (OSError, IOError) as e:
         logger.error(f"File operation failed for platform {python_platform}: {e}", exc_info=True)
         raise RuntimeError(f"File operation failed for platform {python_platform}: {e}")
+
+  WheelBuildException(Exception):
+     pass
+
   except Exception as e:
-        logger.error(f"Unhandled exception in _build_wheel_for_platform for platform {python_platform}: {e}", exc_info=True)
-        raise
+      raise WheelBuildException("Unhandled exception in _build_wheel_for_platform for platform ...") from e

--- a/binary_wheel_builder/api/build.py
+++ b/binary_wheel_builder/api/build.py
@@ -7,7 +7,7 @@ import os
 from collections.abc import Generator
 from operator import attrgetter
 from zipfile import Path
-
+from pathlib import Path
 from binary_wheel_builder import wrapper_templates
 from binary_wheel_builder.api.meta import (Wheel, WheelFileEntry, WheelPlatformBuildResult, WheelPlatformIdentifier,
                                            WheelSource)
@@ -119,7 +119,7 @@ def build_wheel(wheel_meta: Wheel, dist_folder: Path, worker_count: int = 1) -> 
             for future in concurrent.futures.as_completed(futures):
                 if future.exception() is not None:
                    logger.error(f"Sorry, a problem has occurred :(. Ensure all data is correct 
-                   or configured. Exception: {future.exception()}", exc_info=True)
+                                or configured. Exception: {future.exception()}", exc_info=True)
                 else:
                     try:
                         yield future.result()

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -40,9 +40,21 @@ def main(argv=None) -> None:
     args = _parse_args(argv)
 
     dist_path = Path(args.dist_folder)
-    dist_path.mkdir(exist_ok=True)
+    
+   try:
+        dist_path.mkdir(exist_ok=True)
+    except OSError as e:
+        raise SystemExit(f"Failed to create dist folder at '{dist_path}': {e}")
 
     from binary_wheel_builder.cli.config_file import load_wheel_spec_from_yaml
-    wheel = load_wheel_spec_from_yaml(Path(args.wheel_spec))
-    for result in build_wheel(wheel, dist_path, worker_count=args.max_workers):
-        print(f"> {result.checksum} - {result.file_path}")
+     
+    try:
+        wheel = load_wheel_spec_from_yaml(Path(args.wheel_spec))
+    except Exception as e:
+        raise SystemExit(f"Failed to load wheel spec from '{args.wheel_spec}': {e}")
+
+    try:
+        for result in build_wheel(wheel, dist_path, worker_count=args.max_workers):
+            print(f"> {result.checksum} - {result.file_path}")
+    except Exception as e:
+          raise SystemExit(f"Error occurred while building wheels: {e}")

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -27,11 +27,6 @@ def _parse_args(args) -> Namespace:
         type=int,
         help="Number of parallel workers to use at most for building wheels"
     )
-    parser.add_argument(
-        '--version',
-        action='version',
-        version='Wheel Builder 1.0.0'
-    )
     return parser.parse_args(args)
 
 

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -1,9 +1,11 @@
 import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-
+import logging
 from binary_wheel_builder.api import build_wheel
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def _parse_args(args) -> Namespace:
     parser = ArgumentParser("CLI Wheel Builder")

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -1,7 +1,7 @@
+import logging
 import sys
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-import logging
 from binary_wheel_builder.api import build_wheel
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -43,7 +43,7 @@ def main(argv=None) -> None:
 
     dist_path = Path(args.dist_folder)
     
-   try:
+    try:
         dist_path.mkdir(exist_ok=True)
     except OSError as e:
         raise SystemExit(f"Failed to create dist folder at '{dist_path}': {e}")
@@ -59,4 +59,4 @@ def main(argv=None) -> None:
         for result in build_wheel(wheel, dist_path, worker_count=args.max_workers):
             print(f"> {result.checksum} - {result.file_path}")
     except Exception as e:
-          raise SystemExit(f"Error occurred while building wheels: {e}")
+        raise SystemExit(f"Error occurred while building wheels: {e}")

--- a/binary_wheel_builder/cli/main.py
+++ b/binary_wheel_builder/cli/main.py
@@ -25,6 +25,11 @@ def _parse_args(args) -> Namespace:
         type=int,
         help="Number of parallel workers to use at most for building wheels"
     )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='Wheel Builder 1.0.0'
+    )
     return parser.parse_args(args)
 
 


### PR DESCRIPTION
Hello 👋. I have been reading the responses to the changes I added and have taken them into account with the updates I am going to describe below, as I believe they could significantly improve the performance, efficiency and readability of the tool. I hope these small changes seem appropriate to you, let me know when you have time.

### **FIXS:** 

- Replaced print sentences with logging
- Updating error messages for a better understanding and user-friendly
- Added a new argument "--version" in the parse_args function (main.py). This will show the current version of the wheel
- Replaced os module with Path in wheel_file_path variable.  **Reason:**  Using os.path is more operating system error-prone and less readable than pathlib.Path
- Removed ThreadPoolExecutor and added instead ProcessPoolExecutor with a worker_count option and os.cpu_count. 
**Reason**: Currently, construction is parallelized, but the number of workers is not adequately controlled. 
**My solution:** Use concurrent.futures.ProcessPoolExecutor instead of ThreadPoolExecutor to take advantage of multiple CPUs. Use os.cpu_count() function as default for worker_count.

**NOTE**: On previous PR you said that I dropped accidentaly an important line of code, but I review that and that line was only placed to another line below, I don´t know exactly if this will make a problem in future, but it should not have to happen anything wrong.

**BENEFITS**:

- Better understanding about errors and possible bugs
- Better processing performance
- More efficiency 
- More reliability


**SCREENSHOTS:** 

![code_fixed(5)](https://github.com/user-attachments/assets/430bef6e-2cbe-47b9-a441-433bb735b946)
![code_fixed(1)](https://github.com/user-attachments/assets/0c60dcee-8fca-44cc-b34f-df47252dd44e)
![code_fixed(2)](https://github.com/user-attachments/assets/e74a720c-3873-4954-9178-8885e1dd33d5)
![code_fixed](https://github.com/user-attachments/assets/cc7efb32-e5c4-4e72-8804-fd4001df4352)


